### PR TITLE
Rename "activate" to "stimulate" and refactor.

### DIFF
--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -137,9 +137,7 @@ class GraphWindow {
 
 /**** Graph window ****/
 function createGraphWindow(xOrigin, yOrigin, xScale, yScale) {
-  let graphWindow = new GraphWindow(xOrigin, yOrigin, xScale, yScale);
-  magic_graphWindows.push(graphWindow);
-  return graphWindow;
+  return new GraphWindow(xOrigin, yOrigin, xScale, yScale);
 }
 
 /**** drawing ****/

--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -69,9 +69,10 @@ function createMatrix(a, b, c, d) {
 ********************************/
 
 //for now, using a global var to store
-//the two most recent values of mouseIsPressed
+//the two most recent values of mouseIsPressed;
 //used to detect when mouse is newly pressed or newly released,
-//using only p5's built-in system variables (may be a bit kludgy?)
+//using only p5's built-in system variables (may be a bit kludgy?);
+//"magic_" prefix used to reduce the likelihood of being overwritten by the user
 var magic_pressHistory = [false, false];
 
 /**** GraphWindow ****/
@@ -571,15 +572,15 @@ class Draggable {
       };
     
     let getMouseIsDropped = (d) => {
-      let wasPressed = this.w.pressHistory[0];
-      let isPressed = this.w.pressHistory[1];
+      let wasPressed = magic_pressHistory[0];
+      let isPressed = magic_pressHistory[1];
       this.mouseIsDropped = !wasPressed && isPressed && getMouseIsOver(d);
       return this.mouseIsDropped;
     };
     
     let getMouseIsUnpressed = (d) => {
-      let wasPressed = this.w.pressHistory[0];
-      let isPressed = this.w.pressHistory[1];
+      let wasPressed = magic_pressHistory[0];
+      let isPressed = magic_pressHistory[1];
       this.mouseIsUnpressed = wasPressed && !isPressed;
       return this.mouseIsUnpressed;
     };


### PR DESCRIPTION
Renamed "activate" methods in the interaction and drawing sections to "stimulate," since "stimulate" is an action that can happen many times. "Activate" implies an initialization action, so the user would expect it to run in p5's setup function rather than the draw loop.

Removed global variable containing the graph windows since it was no longer needed for the object activation. Replaced it with a global variable for the press history, which was previously attached to each graph window (it might still make sense to implement it at the graph-window level, but a global variable is simpler for now).

Removed unnecessary activation code in runMathemagicalListeners and renamed it to updatePressHistory, since that's all it does now.

Removed unnecessary (and problematic) code in the activate method of the interaction objects (the only interaction object currently implemented is the Draggable). The code I removed registered a [drawing object, interaction object] pair with a graph window by storing the pair in an array that I also removed; the registration was happening in every frame of the draw loop.

Deleted comment in the update method of the Rotation animation object (the only animation object currently in the prototype) that was no longer relevant, since it related to the code I removed from the "activate" method.