### PR TITLE
Rename "update" methods as "takeUpdate" and "giveUpdate."

### DIFF
--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -548,57 +548,57 @@ class Draggable {
     this.offsetY = 0;
     
     //partial listeners (used for the main listeners)
-    let xIsWithinBounds = (d) => {
-        let leftBound = d.getCenterInCanvas().x - d.getWidthInCanvas() / 2;
-        let rightBound = d.getCenterInCanvas().x + d.getWidthInCanvas() / 2;
+    let xIsWithinBounds = (dObject) => {
+        let leftBound = dObject.getCenterInCanvas().x - dObject.getWidthInCanvas() / 2;
+        let rightBound = dObject.getCenterInCanvas().x + dObject.getWidthInCanvas() / 2;
         return (leftBound < mouseX) && (mouseX < rightBound);
     }
     
-    let yIsWithinBounds = (d) => {
-        let topBound = d.getCenterInCanvas().y - d.getHeightInCanvas() / 2;
-        let bottomBound = d.getCenterInCanvas().y + d.getHeightInCanvas() / 2;
+    let yIsWithinBounds = (dObject) => {
+        let topBound = dObject.getCenterInCanvas().y - dObject.getHeightInCanvas() / 2;
+        let bottomBound = dObject.getCenterInCanvas().y + dObject.getHeightInCanvas() / 2;
         return (topBound < mouseY) && (mouseY < bottomBound);
     }
     
     //listeners
-    let getMouseIsOver = (d) => { //d is a drawing object
-        return xIsWithinBounds(d) && yIsWithinBounds(d);
+    let getMouseIsOver = (dObject) => {
+        return xIsWithinBounds(dObject) && yIsWithinBounds(dObject);
       };
     
-    let getMouseIsOut = (d) => { //d is a drawing object
-        return !(xIsWithinBounds(d) && yIsWithinBounds(d));
+    let getMouseIsOut = (dObject) => {
+        return !(xIsWithinBounds(dObject) && yIsWithinBounds(dObject));
       };
     
-    let getMouseIsDropped = (d) => { //dropped: newly pressed
+    let getMouseIsDropped = (dObject) => { //dropped: newly pressed
       let wasPressed = magic_pressHistory[0];
       let isPressed = magic_pressHistory[1];
-      return !wasPressed && isPressed && getMouseIsOver(d);
+      return !wasPressed && isPressed && getMouseIsOver(dObject);
     };
     
-    let getMouseIsLetGo = (d) => { //'LetGo' instead of 'Released' to avoid conflict w/ p5
+    let getMouseIsLetGo = (dObject) => { //'LetGo' instead of 'Released' to avoid conflict w/ p5
       let wasPressed = magic_pressHistory[0];
       let isPressed = magic_pressHistory[1];
       return wasPressed && !isPressed;
     };
     
-    let getMouseIsHeld = (d) => { //'Held' instead of 'Pressed' to avoid conflict w/ p5
-      return mouseIsPressed && mouseIsOver(d);
+    let getMouseIsHeld = (dObject) => { //'Held' instead of 'Pressed' to avoid conflict w/ p5
+      return mouseIsPressed && mouseIsOver(dObject);
     };
 
     //handlers
-    let mouseOver = (d) => cursor(MOVE);
-    let mouseOut = (d) => cursor(ARROW);
+    let mouseOver = (dObject) => cursor(MOVE);
+    let mouseOut = (dObject) => cursor(ARROW);
     
-    let mouseDropped = (d) => {
-      this.offsetX = this.w.X(d.x) - mouseX;
-      this.offsetY = this.w.Y(d.y) - mouseY;
+    let mouseDropped = (dObject) => {
+      this.offsetX = this.w.X(dObject.x) - mouseX;
+      this.offsetY = this.w.Y(dObject.y) - mouseY;
     };
     
-    let mouseLetGo = (d) => { //no handler is currently needed
+    let mouseLetGo = (dObject) => { //no handler is currently needed
     };
     
-    let mouseHeld = (d) => {
-      d.setPositionInCanvas(mouseX + this.offsetX, mouseY + this.offsetY);
+    let mouseHeld = (dObject) => {
+      dObject.setPositionInCanvas(mouseX + this.offsetX, mouseY + this.offsetY);
     };
     
     //listener, handler pairs
@@ -618,12 +618,12 @@ class Draggable {
   }
   
   //pass user input to drawing object
-  giveInput(d) { //d is a drawing object
+  giveInput(dObject) {
     for (const pair of this.interactionPairs) {
       let listener = pair[0];
       let handler = pair[1]; 
-      if (listener(d)) {
-        handler(d);
+      if (listener(dObject)) {
+        handler(dObject);
       }
     }
   }

--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -559,6 +559,7 @@ class Draggable {
     this.w = w; //graph window
     this.offsetX = 0;
     this.offsetY = 0;
+    this.isHeld = false;
     
     //partial listeners (used for the main listeners)
     let xIsWithinBounds = (dObject) => {
@@ -595,7 +596,13 @@ class Draggable {
     };
     
     let getMouseIsHeld = (dObject) => { //'Held' instead of 'Pressed' to avoid conflict w/ p5
-      return mouseIsPressed && getMouseIsOver(dObject);
+      if (getMouseIsDropped(dObject)) {
+          this.isHeld = true;
+      }
+      if (getMouseIsLetGo(dObject)) {
+          this.isHeld = false;
+      }
+      return this.isHeld;
     };
 
     //handlers

--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -570,7 +570,7 @@ class Draggable {
       return !wasPressed && isPressed && getMouseIsOver(d);
     };
     
-    let getMouseIsUnpressed = (d) => { //'unpressed' instead of 'released' to avoid conflict w/ p5
+    let getMouseIsLetGo = (d) => { //'LetGo' instead of 'Released' to avoid conflict w/ p5
       let wasPressed = magic_pressHistory[0];
       let isPressed = magic_pressHistory[1];
       return wasPressed && !isPressed;
@@ -589,7 +589,7 @@ class Draggable {
       this.offsetY = this.w.Y(d.y) - mouseY;
     };
     
-    let mouseUnpressed = (d) => { //no handler is currently needed
+    let mouseLetGo = (d) => { //no handler is currently needed
     };
     
     let mouseHeld = (d) => {
@@ -600,7 +600,7 @@ class Draggable {
     this.mouseOverPair = [getMouseIsOver, mouseOver];
     this.mouseOutPair = [getMouseIsOut, mouseOut];
     this.mouseDroppedPair = [getMouseIsDropped, mouseDropped];
-    this.mouseReleasedPair = [getMouseIsUnpressed, mouseUnpressed];
+    this.mouseReleasedPair = [getMouseIsLetGo, mouseLetGo];
     this.mouseDraggedPair = [getMouseIsHeld, mouseHeld];
     
     this.interactionPairs = [

--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -387,8 +387,8 @@ class Square {
     animationObject.giveUpdate(this);
   }
   
-  stimulate(interactionObject) {
-    interactionObject.stimulate(this);
+  takeInput(interactionObject) {
+    interactionObject.giveInput(this);
   }
 
   render() {
@@ -627,8 +627,8 @@ class Draggable {
     ];
   }
   
-  //activation
-  stimulate(d) { //d is a drawing object
+  //pass user input to drawing object
+  giveInput(d) { //d is a drawing object
     for (const pair of this.interactionPairs) {
       let listener = pair[0];
       let handler = pair[1]; 

--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -541,11 +541,6 @@ class Draggable {
     this.w = w; //GraphingWindow object
     this.offsetX = 0;
     this.offsetY = 0;
-    this.mouseIsOver = false;
-    this.mouseIsOut = false;
-    this.mouseIsDropped = false; //dropped: newly pressed
-    this.mouseIsUnpressed = false; //'unpressed' instead of 'released' to avoid conflict w/ p5
-    this.mouseIsPulled = false; //'pulled' instead of 'dragged' to avoid conflict w/ p5
     
     //partial listeners (used for the main listeners)
     let xIsWithinBounds = (d) => {
@@ -562,37 +557,27 @@ class Draggable {
     
     //listeners
     let getMouseIsOver = (d) => { //d is a drawing object
-        this.mouseIsOver = xIsWithinBounds(d) && yIsWithinBounds(d);
-        return this.mouseIsOver;
+        return xIsWithinBounds(d) && yIsWithinBounds(d);
       };
     
     let getMouseIsOut = (d) => { //d is a drawing object
-        this.mouseIsOut = !(xIsWithinBounds(d) && yIsWithinBounds(d));
-        return this.mouseIsOut;
+        return !(xIsWithinBounds(d) && yIsWithinBounds(d));
       };
     
-    let getMouseIsDropped = (d) => {
+    let getMouseIsDropped = (d) => { //dropped: newly pressed
       let wasPressed = magic_pressHistory[0];
       let isPressed = magic_pressHistory[1];
-      this.mouseIsDropped = !wasPressed && isPressed && getMouseIsOver(d);
-      return this.mouseIsDropped;
+      return !wasPressed && isPressed && getMouseIsOver(d);
     };
     
-    let getMouseIsUnpressed = (d) => {
+    let getMouseIsUnpressed = (d) => { //'unpressed' instead of 'released' to avoid conflict w/ p5
       let wasPressed = magic_pressHistory[0];
       let isPressed = magic_pressHistory[1];
-      this.mouseIsUnpressed = wasPressed && !isPressed;
-      return this.mouseIsUnpressed;
+      return wasPressed && !isPressed;
     };
     
-    let getMouseIsPulled = (d) => { //call after mouseIsDropped & mouseIsUnpressed
-      if (this.mouseIsDropped) {
-        this.mouseIsPulled = true;
-      }
-      if (this.mouseIsUnpressed) {
-        this.mouseIsPulled = false;
-      }
-      return this.mouseIsPulled;
+    let getMouseIsHeld = (d) => { //'Held' instead of 'Pressed' to avoid conflict w/ p5
+      return mouseIsPressed && mouseIsOver(d);
     };
 
     //handlers
@@ -607,7 +592,7 @@ class Draggable {
     let mouseUnpressed = (d) => { //no handler is currently needed
     };
     
-    let mousePulled = (d) => {
+    let mouseHeld = (d) => {
       d.setPositionInCanvas(mouseX + this.offsetX, mouseY + this.offsetY);
     };
     
@@ -616,7 +601,7 @@ class Draggable {
     this.mouseOutPair = [getMouseIsOut, mouseOut];
     this.mouseDroppedPair = [getMouseIsDropped, mouseDropped];
     this.mouseReleasedPair = [getMouseIsUnpressed, mouseUnpressed];
-    this.mouseDraggedPair = [getMouseIsPulled, mousePulled];
+    this.mouseDraggedPair = [getMouseIsHeld, mouseHeld];
     
     this.interactionPairs = [
       this.mouseOverPair, 

--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -524,15 +524,20 @@ class Rotation {
 
 /******************************** INTERACTION
 * Draggable
-* runMathemagicalListeners
+* updatePressHistory
 
-Note: The names 'mouseDropped' and 'mouseUnpressed' are not ideal. It'd be nice to use
-'mouseDown' and 'mouseUp', but a 'mouseup' event in the Element Web API fires only when
-the mouse is released while still inside an element; that's not how our event currently
-works, although that could maybe be changed. However, another issue is that p5.js has
-a function called keyIsDown() that returns true as long as the specified key is pressed
-(not just when it's first pressed); 'mouseIsDropped' is true only when the mouse is
-first pressed.
+Notes: 
+1. The name 'mouseDropped' is not ideal. It'd be nice to use 'mouseDown'
+in place of 'mouseDropped' since the latter's meaning is consistent with a 'mousedown' 
+event in Web APIs (this event occurs once when the mouse is first pressed). 
+However, p5 has a function called keyIsDown() that returns true as long as the 
+specified key is pressed (not just when it's first pressed), which may cause confusion.
+
+2. 'mouseIsLetGo' returns true even if the mouse is let go outside of the drawing
+object. This is inconsistent with mouseIsHeld, and with "mouseup" events in Web
+APIs. However, currently, it's not necessary to check whether the mouse is inside the
+drawing object when it's let go, so the extra condition isn't checked. We may want to 
+add it in at some point.
 ********************************/
 
 /**** Draggable ****/

--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -509,11 +509,11 @@ class Tick {
 
 /**** Rotation ****/
 class Rotation {
-  constructor(w, angle, speed, point) {
+  constructor(w, angle, speed, center) {
     this.w = w; //graph window
     this.angle = angle;
     this.speed = speed; //radians / frame
-    this.point = point; //point about which rotation occurs (not implemented yet)
+    this.center = center; //point about which rotation occurs (not implemented yet)
     this.updateMatrix = createMatrix(cos(speed), sin(speed), -sin(speed), cos(speed));
     this.currentAngle = 0;
   }

--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -454,7 +454,7 @@ class Arrow {
 /**** Axis ****/
 class Axis {
   constructor(w, orientation) {
-    this.w = w; //GraphingWindow object
+    this.w = w; //graph window
     this.orientation = orientation; //'horizontal' or 'vertical'
   }
   
@@ -471,7 +471,7 @@ class Axis {
 /**** Tick ****/
 class Tick {  
   constructor(w, axisOrientation, value = 0, length = 10) {
-    this.w = w; //GraphingWindow object
+    this.w = w; //graph window
     this.axisOrientation = axisOrientation;
     this.value = value;
     this.length = length;
@@ -543,7 +543,7 @@ add it in at some point.
 /**** Draggable ****/
 class Draggable {
   constructor(w) {
-    this.w = w; //GraphingWindow object
+    this.w = w; //graph window
     this.offsetX = 0;
     this.offsetY = 0;
     

--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -383,8 +383,8 @@ class Square {
     return this.s;
   }
   
-  update(animationObject) {
-    animationObject.update(this);
+  takeUpdate(animationObject) {
+    animationObject.giveUpdate(this);
   }
   
   stimulate(interactionObject) {
@@ -507,7 +507,7 @@ class Rotation {
     this.currentAngle = 0;
   }
   
-  update(drawingObject) {
+  giveUpdate(drawingObject) {
     if (this.currentAngle < this.angle) {
       let vertices = drawingObject.verticesInGraph;
       let updatedVertex;

--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -10,11 +10,11 @@ proofs of concept for different types of features:
 * INTERACTION
 
 Notes:
-1. Features that will eventually be supported by multiple classes 
+0. Features that will eventually be supported by multiple classes 
 might only be implemented here for one particular class. Also, for this 
 prototype library, p5.js is used only in global mode.
 
-2. Since the p5 web editor doesn't seem to like private class members 
+1. Since the p5 web editor doesn't seem to like private class members 
 with the modern # prefix, the _ prefix convention is used; however,
 most members are left public for now.
 ********************************/
@@ -25,10 +25,10 @@ most members are left public for now.
 
 Notes:
 
-1. The matrix features just cover some quick special cases that 
+0. The matrix features just cover some quick special cases that 
 are needed or may be needed soon.
 
-2. For future reference, p5 has internal code for matrix stuff:
+1. For future reference, p5 has internal code for matrix stuff:
 https://github.com/processing/p5.js/blob/a66195a45fdd4d0b7396169b09ad2ce6dfffcdd4/src/webgl/p5.Matrix.js#L13
 ********************************/
 
@@ -233,16 +233,16 @@ class Point {
 
   render() {
     //start new drawing state
-    push();
-    strokeWeight(this._strokeWeight);
+    push(); //p5 function
+    strokeWeight(this._strokeWeight); //p5 function
     
     //draw a point at graph coordinates (x, y)
     let canvasX = this.w.X(this.x);
     let canvasY = this.w.Y(this.y);
-    point(canvasX, canvasY);
+    point(canvasX, canvasY); //p5 function
 
     //restore drawing state
-    pop();
+    pop();//p5 function
   }
 }
 
@@ -264,10 +264,13 @@ class Square {
   computeVerticesInCanvas(X, Y) { //X, Y are canvas coords of top-left vertex
     let W = this.getWidthInCanvas();
     let H = this.getHeightInCanvas();
+
+    //create vectors with createVector (a p5 function)
     let TL = createVector(X, Y); //top left
     let TR = createVector(X + W, Y); //top right
     let BR = createVector(X + W, Y + H); //bottom right
     let BL = createVector(X, Y + H); //bottom left
+    
     return [TL, TR, BR, BL];
   }
   
@@ -279,7 +282,7 @@ class Square {
     for (const vertexInCanvas of verticesInCanvas) {
       x = this.w.x(vertexInCanvas.x);
       y = this.w.y(vertexInCanvas.y);
-      vertexInGraph = createVector(x, y);
+      vertexInGraph = createVector(x, y); //p5 function
       verticesInGraph.push(vertexInGraph);
     }
     
@@ -294,7 +297,7 @@ class Square {
     for (const vertexInGraph of verticesInGraph) {
       X = this.w.X(vertexInGraph.x);
       Y = this.w.Y(vertexInGraph.y);
-      vertexInCanvas = createVector(X, Y);
+      vertexInCanvas = createVector(X, Y); //p5 function
       verticesInCanvas.push(vertexInCanvas);
     }
     
@@ -360,7 +363,7 @@ class Square {
     let BR = this.verticesInCanvas[2]; //bottom-right (p5 Vector)
     let centerX = (TL.x + BR.x) / 2; //X-coordinate of center
     let centerY = (TL.y + BR.y) / 2; //Y-coordinate of center
-    return createVector(centerX, centerY);
+    return createVector(centerX, centerY); //p5 function
   }
   
   getWidthInCanvas() { //width in canvas units (i.e. pixels)
@@ -376,7 +379,7 @@ class Square {
     let BR = this.verticesInGraph[2]; //bottom-right (p5 Vector)
     let centerX = (TL.x + BR.x) / 2; //x-coordinate of center
     let centerY = (TL.y + BR.y) / 2; //y-coordinate of center
-    return createVector(centerX, centerY);
+    return createVector(centerX, centerY); //p5 function
   }
   
   getWidth() { //width in graph units
@@ -396,6 +399,7 @@ class Square {
   }
 
   render() {
+    //p5 functions
     beginShape();
     vertex(this.verticesInCanvas[0].x, this.verticesInCanvas[0].y);
     vertex(this.verticesInCanvas[1].x, this.verticesInCanvas[1].y);
@@ -416,7 +420,7 @@ class Arrow {
       
       //point of application defaults to the origin
       if (this.p === undefined) {
-        this.p = createVector(0, 0);
+        this.p = createVector(0, 0); //p5 functions
       }
     }
   
@@ -446,6 +450,8 @@ class Arrow {
     let h1 = p5.Vector.add(b, r);
     let h2 = p5.Vector.sub(b, r);
     
+    //DRAW with p5 functions
+    
     //arrow segment
     line(this.w.X(this.p.x), this.w.Y(this.p.y), this.w.X(tip.x), this.w.Y(tip.y));
     
@@ -464,10 +470,10 @@ class Axis {
   
   render() {
     if (this.orientation === 'horizontal') {
-     line(0, this.w.yOrigin, width, this.w.yOrigin); 
+     line(0, this.w.yOrigin, width, this.w.yOrigin); //p5 function
     }
     else if (this.orientation === 'vertical') {
-      line(this.w.xOrigin, 0, this.w.xOrigin, height);
+      line(this.w.xOrigin, 0, this.w.xOrigin, height); //p5 function
     }
   }
 }
@@ -484,7 +490,8 @@ class Tick {
   render() {
     let cValue; //value at which to draw tick in canvas coordinates
     const h = this.length / 2;
-    
+
+    //DRAW with p5 functions
     if (this.axisOrientation === 'horizontal') {
       cValue = this.w.X(this.value);
       line(cValue, this.w.yOrigin - h, cValue, this.w.yOrigin + h); 
@@ -530,7 +537,9 @@ class Rotation {
 * Draggable
 * updatePressHistory
 
-Notes: 
+Notes:
+0. mouseX, mouseY, mouseIsPressed are system variables in p5
+
 1. The name 'mouseDropped' is not ideal. It'd be nice to use 'mouseDown'
 in place of 'mouseDropped' since the latter's meaning is consistent with a 'mousedown' 
 event in Web APIs (this event occurs once when the mouse is first pressed). 

--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -232,13 +232,17 @@ class Point {
   }
 
   render() {
-    //call p5's native strokeWeight()
+    //start new drawing state
+    push();
     strokeWeight(this._strokeWeight);
     
     //draw a point at graph coordinates (x, y)
     let canvasX = this.w.X(this.x);
     let canvasY = this.w.Y(this.y);
     point(canvasX, canvasY);
+
+    //restore drawing state
+    pop();
   }
 }
 

--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -546,8 +546,8 @@ event in Web APIs (this event occurs once when the mouse is first pressed).
 However, p5 has a function called keyIsDown() that returns true as long as the 
 specified key is pressed (not just when it's first pressed), which may cause confusion.
 
-2. 'mouseIsLetGo' returns true even if the mouse is let go outside of the drawing
-object. This is inconsistent with mouseIsHeld, and with "mouseup" events in Web
+2. 'getMouseIsLetGo' returns true even if the mouse is let go outside of the drawing
+object. This is inconsistent with getMouseIsHeld, and with "mouseup" events in Web
 APIs. However, currently, it's not necessary to check whether the mouse is inside the
 drawing object when it's let go, so the extra condition isn't checked. We may want to 
 add it in at some point.
@@ -595,7 +595,7 @@ class Draggable {
     };
     
     let getMouseIsHeld = (dObject) => { //'Held' instead of 'Pressed' to avoid conflict w/ p5
-      return mouseIsPressed && mouseIsOver(dObject);
+      return mouseIsPressed && getMouseIsOver(dObject);
     };
 
     //handlers


### PR DESCRIPTION
Drawing objects and animation objects each have update methods. In both cases, they both involve updates, but in different directions. The new names reflect this. 

In particular, mySquare.takeUpdate(myRotation) tells mySquare to take update instructions from myRotation, whereas myRotation.giveUpdate(mySquare) tells myRotation to give update instructions to mySquare. 

Most likely, only takeUpdate() needs to be exposed to the user, but there is another advantage to this naming scheme: it's easier to use in other circumstances. For example, we can also have "takeInput" and "giveInput" methods for user interactions.

This solves the problem of finding a satisfactory name for the method that lets drawing objects respond to user interaction.