### PR TITLE
Improve event listener/handler interface

### DIFF
--- a/demos/deactivate-default-responders-demo.js
+++ b/demos/deactivate-default-responders-demo.js
@@ -1,0 +1,69 @@
+/* DRAG THE SQUARE
+ * This is a demo sketch for a p5.js library called 
+ * Mathemagical.js. It shows how to deactivate and reactivate
+ * default event responders. To see how 
+ * reactivateDefaultResponder() works, uncomment the line that 
+ * calls that method.
+ *
+ * The code that makes this sketch work can be found in the 
+ * mathemagical-prototype.js file in this project's directory. 
+ * That file constitutes an early prototype of Mathemagical.js.
+ * Only a small sample of the planned features are currently 
+ * included.
+ */
+
+let xOrigin, yOrigin;
+let xScale, yScale; //px per unit
+let xAxis, yAxis;
+let w; //graphing window
+let mySquare;
+let myDraggable;
+
+function setup() {
+  createCanvas(400, 400);
+  
+  //graph window
+  xOrigin = width / 2;
+  yOrigin = height / 2;
+  xScale = 20; //px per unit
+  yScale = 20; //px per unit
+  w = createGraphWindow(xOrigin, yOrigin, xScale, yScale);
+  
+  //axes
+  xAxis = w.createAxis('horizontal');
+  yAxis = w.createAxis('vertical');
+  
+  //square 
+  //constructor takes same parameters as p5's square(), 
+  //but specified in the coordinate system of the graph window
+  mySquare = w.createSquare(-1, 1, 2);
+  
+  //draggable
+  myDraggable = w.createDraggable();
+  
+  myDraggable.addEventResponder('mouseover', myMouseOverResponder);
+  myDraggable.addEventResponder('mouseout', myMouseOutResponder);
+  
+  myDraggable.deactivateDefaultResponder('mouseover'); 
+  //myDraggable.reactivateDefaultResponder('mouseover');
+}
+
+function draw() {
+  background(240);
+  
+  //Axes
+  w.axis(xAxis);
+  w.axis(yAxis);
+  
+  //Square
+  mySquare.takeInput(myDraggable);
+  w.square(mySquare);
+}
+
+function myMouseOverResponder(drawingObject) {
+  drawingObject.strokeWeight(3);
+}
+
+function myMouseOutResponder(drawingObject) {
+  drawingObject.strokeWeight(1);
+}

--- a/demos/multiple-event-responders-demo.js
+++ b/demos/multiple-event-responders-demo.js
@@ -1,0 +1,69 @@
+/* DRAG THE SQUARE
+ * This is a proof-of-concept sketch of custom event responders
+ * for a p5.js library called Mathemagical.js. Specifically, this
+ * sketch demonstrates Mathemagical's addEventResponder() and 
+ * deleteEventResponder(). To see deleteEventResponder() work, 
+ * uncomment the lines that call that method.
+ *
+ * The code that makes this sketch work can be found in the 
+ * mathemagical-prototype.js file in this project's directory. 
+ * That file constitutes an early prototype of Mathemagical.js.
+ * Only a small sample of the planned features are currently 
+ * included.
+ */
+
+let xOrigin, yOrigin;
+let xScale, yScale; //px per unit
+let xAxis, yAxis;
+let w; //graphing window
+let mySquare;
+let myDraggable;
+
+function setup() {
+  createCanvas(400, 400);
+  
+  //graph window
+  xOrigin = width / 2;
+  yOrigin = height / 2;
+  xScale = 20; //px per unit
+  yScale = 20; //px per unit
+  w = createGraphWindow(xOrigin, yOrigin, xScale, yScale);
+  
+  //axes
+  xAxis = w.createAxis('horizontal');
+  yAxis = w.createAxis('vertical');
+  
+  //square 
+  //constructor takes same parameters as p5's square(), 
+  //but specified in the coordinate system of the graph window
+  mySquare = w.createSquare(-1, 1, 2);
+  
+  //draggable
+  myDraggable = w.createDraggable();
+  
+  myDraggable.addEventResponder('mouseover', myMouseOverResponder);
+  myDraggable.addEventResponder('mouseout', myMouseOutResponder);
+  
+  //myDraggable.deleteEventResponder('mouseover', myMouseOverResponder);
+  //myDraggable.deleteEventResponder('mouseout', myMouseOutResponder);  
+}
+
+function draw() {
+  background(240);
+  
+  //Axes
+  w.axis(xAxis);
+  w.axis(yAxis);
+  
+  //Square
+  mySquare.takeInput(myDraggable);
+  w.square(mySquare);
+}
+
+function myMouseOverResponder(drawingObject) {
+  drawingObject.strokeWeight(3);
+}
+
+function myMouseOutResponder(drawingObject) {
+  drawingObject.strokeWeight(1);
+}

--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -644,14 +644,19 @@ class Draggable {
       switch (type) {
         case 'mouseover':
           this.mouseOverPair[0] = detector;
+          break;
         case 'mouseout':
           this.mouseOutPair[0] = detector;
+          break;
         case 'mousejustpressed':
           this.mouseJustPressedPair[0] = detector;
+          break;
         case 'mousereleased':
           this.mouseReleasedPair[0] = detector;
+          break;
         case 'mousepressed':
           this.mousePressedPair[0] = detector;
+          break;
         default:
           throw new Error('Event type not currently supported. Please check docs and check for typos.');
       }
@@ -666,14 +671,19 @@ class Draggable {
       switch (type) {
         case 'mouseover':
           this.mouseOverPair[1] = responder;
+          break;
         case 'mouseout':
           this.mouseOutPair[1] = responder;
+          break;
         case 'mousejustpressed':
           this.mouseJustPressedPair[1] = responder;
+          break;
         case 'mousereleased':
           this.mouseReleasedPair[1] = responder;
+          break;
         case 'mousepressed':
           this.mousePressedPair[1] = responder;
+          break;
         default:
           throw new Error('Event type not currently supported. Please check docs and check for typos.');
       }

--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -668,7 +668,7 @@ class Draggable {
     if (type in this.responders) {
       this.responders.get(type).add(responder);
     } else {
-      console.log(`Event type ${type} not currently supported. Please check docs and check for typos.`)
+      console.error(`Event type ${type} not currently supported. Please check docs and check for typos.`)
     }
   }
 }

--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -702,6 +702,13 @@ class Draggable {
     }
   }
   
+  /*
+  TODO: At this stage, we haven't focused on error handling. However, since we noticed
+  that a typo in the argument passed to the deactivate method could lead to accidentally creating 
+  a new event type, we went ahead and added some error messages to this set of methods. It would be 
+  good to abstract out the errors so that the same error message isn't repeated.
+  */
+  
   addEventResponder(type, responder) {
     if (this.customResponders.has(type)) {
       const responders = this.customResponders.get(type)
@@ -721,12 +728,22 @@ class Draggable {
   }
   
   deactivateDefaultResponder(type) {
-    this.defaultResponders.set(type, () => {});  
+    if (this.defaultResponders.has(type)) {
+      this.defaultResponders.set(type, () => {});
+    }
+    else {
+      console.error(`Event type ${type} not currently supported. Please check docs and check for typos.`)
+    }
   }
 
   reactivateDefaultResponder(type) {
-    const defaultResponder = this.defaultRespondersReference.get(type);
-    this.defaultResponders.set(type, defaultResponder);  
+    if (this.defaultRespondersReference.has(type)) {
+      const defaultResponder = this.defaultRespondersReference.get(type);
+      this.defaultResponders.set(type, defaultResponder);
+    }
+    else {
+      console.error(`Event type ${type} not currently supported. Please check docs and check for typos.`)
+    }    
   }
 }
 

--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -658,7 +658,7 @@ class Draggable {
           this.mousePressedPair[0] = detector;
           break;
         default:
-          throw new Error('Event type not currently supported. Please check docs and check for typos.');
+          throw new Error(`Event type ${type} not currently supported. Please check docs and check for typos.`);
       }
     }
     catch (error) {
@@ -685,7 +685,7 @@ class Draggable {
           this.mousePressedPair[1] = responder;
           break;
         default:
-          throw new Error('Event type not currently supported. Please check docs and check for typos.');
+          throw new Error(`Event type ${type} not currently supported. Please check docs and check for typos.`);
       }
     }
     catch (error) {

--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -663,10 +663,28 @@ class Draggable {
       console.error(`Event type ${type} not currently supported. Please check docs and check for typos.`);
     }
   }
+
+  removeEventDetecter(type, detector) {
+    if (this.detectors.has(type)) {
+      const detectorsOfType = this.detectors.get(type);
+      detectorsOfType.remove(detector)
+    } else {
+      console.error(`Event type ${type} not currently supported. Please check docs and check for typos.`);
+    }
+  }
   
   addEventResponder(type, responder) {
     if (type in this.responders) {
       this.responders.get(type).add(responder);
+    } else {
+      console.error(`Event type ${type} not currently supported. Please check docs and check for typos.`)
+    }
+  }
+
+  removeEventResponder(type, responder) {
+    if (this.responders.has(type)) {
+      const respondersOfType = this.responders.get(type);
+      respondersOfType.remove(responder)
     } else {
       console.error(`Event type ${type} not currently supported. Please check docs and check for typos.`)
     }

--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -532,6 +532,7 @@ class Rotation {
 /*
 * EVENT_TYPES:
 * Complete enumeration of the built-in event types
+* Users can specify types like 'mouseover' or EVENT_TYPES.mouseover (e.g. for use with their IDE's auto-complete).
 */
 const EVENT_TYPES = Object.freeze({
   mouseover: 'mouseover',

--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -529,6 +529,20 @@ class Rotation {
 }
 
 /******************************** INTERACTION
+/*
+* Interaction types
+* Complete enumeration of the built-in interactions.
+*/
+const Interaction = Object.freeze({
+  mouseover: 'mouseover',
+  mouseout: 'mouseout',
+  mousejustpressed: 'mousejustpressed',
+  mousereleased: 'mousereleased',
+  mousepressed: 'mousepressed'
+});
+
+
+/*
 * Draggable
 * updatePressHistory
 
@@ -612,85 +626,49 @@ class Draggable {
     };
     
     //listener, handler pairs
-    this.mouseOverPair = [mouseOverDetector, mouseOverResponder];
-    this.mouseOutPair = [mouseOutDetector, mouseOutResponder];
-    this.mouseJustPressedPair = [mouseJustPressedDetector, mouseJustPressedResponder];
-    this.mouseReleasedPair = [mouseReleasedDetector, mouseReleasedResponder];
-    this.mousePressedPair = [mousePressedDetector, mousePressedResponder];
-    
-    this.interactionPairs = [
-      this.mouseOverPair, 
-      this.mouseOutPair,
-      this.mouseJustPressedPair, 
-      this.mouseReleasedPair,
-      this.mousePressedPair
-    ];
-  }
+    this.detectors = new Map([
+      [Interaction.mouseover, new Set([mouseOverDetector])], 
+      [Interaction.mouseout, new Set([mouseOutDetector])],
+      [Interaction.mousejustpressed, new Set([mouseJustPressedDetector])],
+      [Interaction.mousereleased, new Set([mouseReleasedDetector])],
+      [Interaction.mousepressed, new Set([mousePressedDetector])],
+    ]);
+    this.responders = new Map([
+      [Interaction.mouseover, new Set([mouseOverResponder])],
+      [Interaction.mouseout, new Set([mouseOutResponder])],
+      [Interaction.mousejustpressed, new Set([mouseJustPressedResponder])],
+      [Interaction.mousereleased, new Set([mouseReleasedResponder])],
+      [Interaction.mousepressed, new Set([mousePressedResponder])],
+    ]);
+  };
   
   //pass user input to drawing object
   giveInput(dObject) {
-    for (const pair of this.interactionPairs) {
-      let detector = pair[0];
-      let responder = pair[1]; 
-      if (detector(dObject)) {
-        responder(dObject);
+    for (const interactionType in Interaction) {
+      for (const detector of this.detectors.get(interactionType)) {
+        if (!detector(dObject))
+          continue;
+        for (const responder of this.responders.get(interactionType))
+          responder(dObject);
+        break;
       }
     }
   }
 
-  //setters for listeners and handlers
-  setEventDetector(type, detector) {
-    try {
-      switch (type) {
-        case 'mouseover':
-          this.mouseOverPair[0] = detector;
-          break;
-        case 'mouseout':
-          this.mouseOutPair[0] = detector;
-          break;
-        case 'mousejustpressed':
-          this.mouseJustPressedPair[0] = detector;
-          break;
-        case 'mousereleased':
-          this.mouseReleasedPair[0] = detector;
-          break;
-        case 'mousepressed':
-          this.mousePressedPair[0] = detector;
-          break;
-        default:
-          throw new Error(`Event type ${type} not currently supported. Please check docs and check for typos.`);
-      }
-    }
-    catch (error) {
-      console.error(error.message);
+  addEventDetector(type, detector) {
+    if (type in this.detectors) {
+      this.detectors.get(type).add(detector);
+    } else {
+      console.error(`Event type ${type} not currently supported. Please check docs and check for typos.`);
     }
   }
   
-  setEventResponder(type, responder) {
-    try {
-      switch (type) {
-        case 'mouseover':
-          this.mouseOverPair[1] = responder;
-          break;
-        case 'mouseout':
-          this.mouseOutPair[1] = responder;
-          break;
-        case 'mousejustpressed':
-          this.mouseJustPressedPair[1] = responder;
-          break;
-        case 'mousereleased':
-          this.mouseReleasedPair[1] = responder;
-          break;
-        case 'mousepressed':
-          this.mousePressedPair[1] = responder;
-          break;
-        default:
-          throw new Error(`Event type ${type} not currently supported. Please check docs and check for typos.`);
-      }
+  addEventResponder(type, responder) {
+    if (type in this.responders) {
+      this.responders.get(type).add(responder);
+    } else {
+      console.log(`Event type ${type} not currently supported. Please check docs and check for typos.`)
     }
-    catch (error) {
-        console.error(error.message);
-      }
   }
 }
 

--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -530,10 +530,10 @@ class Rotation {
 
 /******************************** INTERACTION
 /*
-* Interaction types
-* Complete enumeration of the built-in interactions.
+* EVENT_TYPES:
+* Complete enumeration of the built-in event types
 */
-const Interaction = Object.freeze({
+const EVENT_TYPES = Object.freeze({
   mouseover: 'mouseover',
   mouseout: 'mouseout',
   mousejustpressed: 'mousejustpressed',

--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -628,28 +628,28 @@ class Draggable {
     
     //listener, handler pairs
     this.detectors = new Map([
-      [Interaction.mouseover, new Set([mouseOverDetector])], 
-      [Interaction.mouseout, new Set([mouseOutDetector])],
-      [Interaction.mousejustpressed, new Set([mouseJustPressedDetector])],
-      [Interaction.mousereleased, new Set([mouseReleasedDetector])],
-      [Interaction.mousepressed, new Set([mousePressedDetector])],
+      [EVENT_TYPES.mouseover, new Set([mouseOverDetector])], 
+      [EVENT_TYPES.mouseout, new Set([mouseOutDetector])],
+      [EVENT_TYPES.mousejustpressed, new Set([mouseJustPressedDetector])],
+      [EVENT_TYPES.mousereleased, new Set([mouseReleasedDetector])],
+      [EVENT_TYPES.mousepressed, new Set([mousePressedDetector])],
     ]);
     this.responders = new Map([
-      [Interaction.mouseover, new Set([mouseOverResponder])],
-      [Interaction.mouseout, new Set([mouseOutResponder])],
-      [Interaction.mousejustpressed, new Set([mouseJustPressedResponder])],
-      [Interaction.mousereleased, new Set([mouseReleasedResponder])],
-      [Interaction.mousepressed, new Set([mousePressedResponder])],
+      [EVENT_TYPES.mouseover, new Set([mouseOverResponder])],
+      [EVENT_TYPES.mouseout, new Set([mouseOutResponder])],
+      [EVENT_TYPES.mousejustpressed, new Set([mouseJustPressedResponder])],
+      [EVENT_TYPES.mousereleased, new Set([mouseReleasedResponder])],
+      [EVENT_TYPES.mousepressed, new Set([mousePressedResponder])],
     ]);
   };
   
   //pass user input to drawing object
   giveInput(dObject) {
-    for (const interactionType in Interaction) {
-      for (const detector of this.detectors.get(interactionType)) {
+    for (const eventType in EVENT_TYPES) {
+      for (const detector of this.detectors.get(eventType)) {
         if (!detector(dObject))
           continue;
-        for (const responder of this.responders.get(interactionType))
+        for (const responder of this.responders.get(eventType))
           responder(dObject);
         break;
       }

--- a/mathemagical-prototype.js
+++ b/mathemagical-prototype.js
@@ -588,7 +588,7 @@ class Draggable {
       if (mouseJustPressedDetector(dObject)) {
           this.mouseIsPressed = true;
       }
-      if (getMouseIsLetGo(dObject)) {
+      if (mouseReleasedDetector(dObject)) {
           this.mouseIsPressed = false;
       }
       return this.mouseIsPressed;
@@ -660,9 +660,9 @@ class Draggable {
         default:
           throw new Error('Event type not currently supported. Please check docs and check for typos.');
       }
-      catch (error) {
-        console.error(error.message);
-      }
+    }
+    catch (error) {
+      console.error(error.message);
     }
   }
   
@@ -687,7 +687,8 @@ class Draggable {
         default:
           throw new Error('Event type not currently supported. Please check docs and check for typos.');
       }
-      catch (error) {
+    }
+    catch (error) {
         console.error(error.message);
       }
   }


### PR DESCRIPTION
**THE REASON FOR THIS CHANGE**
The previous interface caused confusion. For example, <code>setObjectIsHovered</code> might be interpreted as a setter for a Boolean (which it is not), rather than as a setter for a method that returns a Boolean (which it is). This problem was surfaced by pull request #9.

**CRITERIA FOR THE NEW INTERFACE**
The interface in this PR is intended to alleviate confusion by satisfying the following design criteria:

* flexible enough to handle a wide range of events
* intuitive enough for beginners 
* consistent enough with p5

**THE NEW INTERFACE**
Here's the new interface:

<code>setEventDetector(type, detector)</code>
<code>setEventResponder(type, responder)</code>

- **type:** a string (e.g. <code>‘mousepressed’</code> and <code>‘mousereleased’</code>)
- **detector, responder:** callback functions for the listener and handler, respectively[^1]

[^1]: "Detector" and "responder" are hopefully more intuitive to beginners than "listener" and "handler."

Note that the <code>type</code> parameter supports the exact names of p5 handlers, such as mousePressed().[^2] When there's no corresponding event handler in p5, we'll typically match Web API names (e.g. <code>‘mouseover’</code> and <code>‘mouseout’</code>), but we may choose our own names if there's a good reason to do so. This pull request also renames some internal variables using a more intuitive naming scheme that matches the new interface.

[^2]: Since event types are passed as strings, they're all lowercase, but otherwise they have the same names as p5 event handlers when applicable.

**COMPARISON TO OTHER INTERFACES**
The approach in this pull request is similar to the [<code>addEventListener()</code>](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) method of the EventTarget Web API and the [<code>.on()</code>](https://konvajs.org/api/Konva.Node.html#on__anchor) method of Konva.js. One major difference is that <code>setEventDetector()</code> and <code>setEventResponder()</code> are attached to a Mathemagical interaction object, rather than the ultimate event target (a drawing object).

This way, the user only needs to create a single interaction object in order to apply multiple listeners and handlers (e.g. for a draggable square, multiple listeners and handlers are used to change the cursor on mouseover and mouseout events, and also to change the position on drag events).