### PR TITLE
Delete google8c3cdb2e8d0c24bb.html

### DIFF
--- a/google8c3cdb2e8d0c24bb.html
+++ b/google8c3cdb2e8d0c24bb.html
@@ -1,1 +1,0 @@
-google-site-verification: google8c3cdb2e8d0c24bb.html


### PR DESCRIPTION
This is a verification file that was created with the intention of getting the Mathemagical.js repo indexed by Google, so that people could find it through a web search.

However, the verification failed, since I was trying to verify https://github.com/Mathemagical-Community/Mathemagical.js, but the verification file is located in https://github.com/Mathemagical-Community/Mathemagical.js/blob/main/

Here's a GitHub discussion that describes another approach, which involves deploying the repo via GitHub Pages: https://github.com/orgs/community/discussions/42375

That may not be ideal, since I think it'd create a new page on a separate URL that just duplicates what we already have in the README. It probably makes more sense to wait until we can set up a project site with its own content.

I imagine Google will index our repo automatically before that happens; once we start sharing the repo and linking to it from other places, such as Reddit, Google will probably find it with a crawler.